### PR TITLE
refactor: API prefix 수정

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -41,8 +41,8 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-app.include_router(embedding_router)
-app.include_router(outfit_router)
+app.include_router(embedding_router, prefix="/ai")
+app.include_router(outfit_router, prefix="/ai")
 
 
 @app.get("/")

--- a/tests/embedding/test_router.py
+++ b/tests/embedding/test_router.py
@@ -29,7 +29,7 @@ def test_create_embedding_api_success(
     }
 
     # When
-    response = client.post("/v1/closet/embedding", json=request_data)
+    response = client.post("/ai/v1/closet/embedding", json=request_data)
 
     # Then
     assert response.status_code == 200
@@ -48,7 +48,7 @@ def test_delete_embedding_api_success(
     clothes_id = 1
 
     # When
-    response = client.delete(f"/v1/closet/{clothes_id}")
+    response = client.delete(f"/ai/v1/closet/{clothes_id}")
 
     # Then
     assert response.status_code == 200

--- a/tests/outfit/test_router.py
+++ b/tests/outfit/test_router.py
@@ -43,7 +43,7 @@ def test_recommend_outfit_success(
     }
 
     # When
-    response = client.post("/v1/closet/outfit", json=request_data)
+    response = client.post("/ai/v1/closet/outfit", json=request_data)
 
     # Then
     assert response.status_code == 200
@@ -69,7 +69,7 @@ def test_recommend_outfit_llm_error(
     }
 
     # When
-    response = client.post("/v1/closet/outfit", json=request_data)
+    response = client.post("/ai/v1/closet/outfit", json=request_data)
 
     # Then
     assert response.status_code == 503
@@ -92,7 +92,7 @@ def test_recommend_outfit_parse_error(
     }
 
     # When
-    response = client.post("/v1/closet/outfit", json=request_data)
+    response = client.post("/ai/v1/closet/outfit", json=request_data)
 
     # Then
     assert response.status_code == 400


### PR DESCRIPTION
## ⭐️ Issue Number

- #39 
- resolves: #39 

## 🚩 Summary

- 인프라의 변경사항으로 인해 모든 API 엔드포인트에 `/ai` prefix 추가하였습니다
- 테스트 코드의 API 경로도 동일하게 수정하였습니다.

## AS-IS

| API | 경로 |
|-----|------|
| 임베딩 저장 | `POST /v1/closet/embedding` |
| 아이템 삭제 | `DELETE /v1/closet/{clothesId}` |
| 코디 추천 | `POST /v1/closet/outfit` |

## TO-BE

| API | 경로 |
|-----|------|
| 임베딩 저장 | `POST /ai/v1/closet/embedding` |
| 아이템 삭제 | `DELETE /ai/v1/closet/{clothesId}` |
| 코디 추천 | `POST /ai/v1/closet/outfit` |

## 🛠️ Technical Concerns

추후에 확장성을 고려하여 서브도메인도 고려 예정입니다.

## 🙂 To Reviewer