### PR TITLE
Langfuse 연동

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,9 @@ NAVER_CLIENT_SECRET=your_naver_client_secret_here
 USE_MOCK_ANALYZER=false
 # AI Server (GCP)
 GCP_SERVER_URL=your_gcp_server_ip
+
+# Langfuse (LLM Observability)
+LANGFUSE_ENABLED=true
+LANGFUSE_SECRET_KEY=your_langfuse_secret_key_here
+LANGFUSE_PUBLIC_KEY=your_langfuse_public_key_here
+LANGFUSE_HOST=http://localhost:3001

--- a/app/config.py
+++ b/app/config.py
@@ -54,6 +54,11 @@ class Settings(BaseSettings):
 
     use_mock_analyzer: bool = Field(default=False, alias="USE_MOCK_ANALYZER")
 
+    langfuse_enabled: bool = Field(default=True, alias="LANGFUSE_ENABLED")
+    langfuse_secret_key: str | None = Field(default=None, alias="LANGFUSE_SECRET_KEY")
+    langfuse_public_key: str | None = Field(default=None, alias="LANGFUSE_PUBLIC_KEY")
+    langfuse_host: str = Field(default="http://localhost:3000", alias="LANGFUSE_HOST")
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/app/embedding/formatter.py
+++ b/app/embedding/formatter.py
@@ -10,12 +10,6 @@ class EmbeddingTextFormatter(Protocol):
 
 
 class HybridFormatter:
-    """
-    출력 예시:
-        "검정 울 코트. 포멀 스타일. 겨울용. 미니멀, 클래식. 면접, 출근에 적합.
-         오버핏 더블 버튼 코트로 세련된 분위기를 연출합니다."
-    """
-
     def format(
         self: "HybridFormatter", major: MajorAttributes, extra: ExtraAttributes
     ) -> str:

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from fastapi.responses import JSONResponse
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.closet.router import router as closet_router
+from app.config import get_settings
 from app.core.database import check_health, close_databases, init_databases
 from app.embedding.router import router as embedding_router
 from app.outfit.router import router as outfit_router
@@ -19,11 +20,49 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+def _init_langfuse() -> None:
+    """Langfuse 초기화 — @observe 데코레이터가 사용하는 langfuse_context 설정"""
+    settings = get_settings()
+    if not settings.langfuse_enabled:
+        logger.info("Langfuse disabled (LANGFUSE_ENABLED=false)")
+        return
+
+    if not settings.langfuse_secret_key or not settings.langfuse_public_key:
+        logger.warning("Langfuse enabled but keys not set, skipping initialization")
+        return
+
+    from langfuse.decorators import langfuse_context
+
+    langfuse_context.configure(
+        secret_key=settings.langfuse_secret_key,
+        public_key=settings.langfuse_public_key,
+        host=settings.langfuse_host,
+        enabled=True,
+    )
+    logger.info("Langfuse initialized (host=%s)", settings.langfuse_host)
+
+
+def _shutdown_langfuse() -> None:
+    """Langfuse 종료 시 미전송 데이터 flush"""
+    settings = get_settings()
+    if not settings.langfuse_enabled:
+        return
+
+    try:
+        from langfuse.decorators import langfuse_context
+
+        langfuse_context.flush()
+        logger.info("Langfuse flushed successfully")
+    except Exception as e:
+        logger.warning("Langfuse flush failed: %s", e)
+
+
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     logger.info("start server")
     try:
         await init_databases()
+        _init_langfuse()
         logger.info("Application startup complete")
     except Exception as e:
         logger.error(f"Failed to start application: {e}")
@@ -33,6 +72,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
     logger.info("shut down server")
     try:
+        _shutdown_langfuse()
         await close_databases()
         logger.info("Application shutdown complete")
     except Exception as e:

--- a/app/outfit/llm_client.py
+++ b/app/outfit/llm_client.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 import openai
+from langfuse.decorators import langfuse_context, observe
 from pydantic import BaseModel
 
 from app.config import Settings, get_settings
@@ -37,6 +38,7 @@ class OpenAIClient(LLMClient):
         )
         self.model = self.settings.openai_chat_model
 
+    @observe(as_type="generation", name="openai_chat_completion")
     async def chat_completion(
         self: "OpenAIClient",
         messages: list[dict[str, Any]],
@@ -44,6 +46,16 @@ class OpenAIClient(LLMClient):
         temperature: float = 0.7,
         max_tokens: int = 2000,
     ) -> BaseModel | dict[str, Any]:
+        # Langfuse generation 입력 메타데이터 기록
+        langfuse_context.update_current_observation(
+            input=messages,
+            model=self.model,
+            model_parameters={
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+            },
+        )
+
         try:
             if response_format is not None:
                 completion = await self._client.beta.chat.completions.parse(
@@ -56,6 +68,23 @@ class OpenAIClient(LLMClient):
                 parsed = completion.choices[0].message.parsed
                 if parsed is None:
                     raise LLMError("Structured Output parsing returned None")
+
+                langfuse_context.update_current_observation(
+                    output=parsed.model_dump()
+                    if hasattr(parsed, "model_dump")
+                    else str(parsed),
+                    usage={
+                        "input": completion.usage.prompt_tokens
+                        if completion.usage
+                        else 0,
+                        "output": completion.usage.completion_tokens
+                        if completion.usage
+                        else 0,
+                        "total": completion.usage.total_tokens
+                        if completion.usage
+                        else 0,
+                    },
+                )
                 return parsed
 
             else:
@@ -65,7 +94,24 @@ class OpenAIClient(LLMClient):
                     temperature=temperature,
                     max_tokens=max_tokens,
                 )
-                return completion.model_dump()
+                result = completion.model_dump()
+
+                # Langfuse generation 출력 메타데이터 기록
+                langfuse_context.update_current_observation(
+                    output=result,
+                    usage={
+                        "input": completion.usage.prompt_tokens
+                        if completion.usage
+                        else 0,
+                        "output": completion.usage.completion_tokens
+                        if completion.usage
+                        else 0,
+                        "total": completion.usage.total_tokens
+                        if completion.usage
+                        else 0,
+                    },
+                )
+                return result
 
         except openai.AuthenticationError as e:
             logger.error("OpenAI 인증 실패: %s", e)

--- a/app/outfit/outfit_composer.py
+++ b/app/outfit/outfit_composer.py
@@ -1,6 +1,8 @@
 import logging
 import uuid
 
+from langfuse.decorators import observe
+
 from app.common.llm_schemas import OutfitCompositionLLMResponse
 from app.common.metrics import measure_time
 from app.outfit.exceptions import LLMError, ParseError
@@ -30,6 +32,7 @@ class OutfitComposer:
     def __init__(self, llm_client: LLMClient | None = None) -> None:
         self.llm_client = llm_client or OpenAIClient()
 
+    @observe(name="outfit_composer.compose")
     @measure_time("outfit_composer")
     async def compose(
         self,

--- a/app/outfit/query_parser.py
+++ b/app/outfit/query_parser.py
@@ -1,5 +1,7 @@
 import logging
 
+from langfuse.decorators import observe
+
 from app.common.llm_schemas import OutfitQueryLLMResponse
 from app.common.metrics import measure_time
 from app.outfit.exceptions import LLMError, ParseError
@@ -29,6 +31,7 @@ class QueryParser:
     def __init__(self, llm_client: LLMClient) -> None:
         self.llm_client = llm_client
 
+    @observe(name="query_parser.parse")
     @measure_time("query_parser")
     async def parse(
         self, query: str, trace_id: str | None = None, user_id: int | None = None

--- a/app/outfit/repository.py
+++ b/app/outfit/repository.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 
+from langfuse.decorators import observe
 from qdrant_client import AsyncQdrantClient
 from qdrant_client.http import models as qdrant_models
 from qdrant_client.http.models import ScoredPoint
@@ -83,6 +84,7 @@ class ClothingRepository:
 
         return SearchResult(category=category, candidates=candidates)
 
+    @observe(name="outfit_vector_search")
     @measure_time("vector_search")
     async def search_multiple(
         self,

--- a/app/outfit/router.py
+++ b/app/outfit/router.py
@@ -3,6 +3,7 @@ import uuid
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from langfuse.decorators import langfuse_context, observe
 
 from app.outfit.exceptions import LLMError, ParseError
 from app.outfit.schemas import OutfitRequest, OutfitResponse
@@ -13,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 @router.post("/outfit", response_model=OutfitResponse, status_code=status.HTTP_200_OK)
+@observe(name="outfit_recommend")
 async def recommend_outfit(
     request: OutfitRequest,
     service: Annotated[OutfitService, Depends(get_outfit_service)],
@@ -20,6 +22,15 @@ async def recommend_outfit(
     trace_id = str(uuid.uuid4())
     query_preview = (
         f"{request.query[:50]}..." if len(request.query) > 50 else request.query
+    )
+
+    # Langfuse 트레이스 메타데이터 설정
+    langfuse_context.update_current_trace(
+        name="outfit_recommend",
+        user_id=str(request.user_id),
+        session_id=request.session_id,
+        metadata={"trace_id": trace_id},
+        input={"query": request.query, "user_id": request.user_id},
     )
 
     logger.info(
@@ -37,6 +48,9 @@ async def recommend_outfit(
             f"trace_id={trace_id} "
             f"user_id={request.user_id} "
             f"outfit_count={len(response.outfits)}"
+        )
+        langfuse_context.update_current_trace(
+            output={"outfit_count": len(response.outfits)},
         )
         return response
 

--- a/app/outfit/service.py
+++ b/app/outfit/service.py
@@ -2,6 +2,8 @@ import logging
 import uuid
 from functools import lru_cache
 
+from langfuse.decorators import observe
+
 from app.common.metrics import OUTFIT_PIPELINE_TOTAL_DURATION, measure_time
 from app.outfit.llm_client import OpenAIClient
 from app.outfit.outfit_composer import OutfitComposer
@@ -29,6 +31,7 @@ class OutfitService:
         self.composer = composer or OutfitComposer()
         self.vton_processor = vton_processor or VTONProcessor()
 
+    @observe(name="outfit_service.recommend")
     @measure_time(stage="total_pipeline", metric=OUTFIT_PIPELINE_TOTAL_DURATION)
     async def recommend(
         self, request: OutfitRequest, trace_id: str | None = None

--- a/app/outfit/vton_client.py
+++ b/app/outfit/vton_client.py
@@ -8,6 +8,7 @@ import base64
 import logging
 
 import httpx
+from langfuse.decorators import observe
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
@@ -90,6 +91,7 @@ Generate a single image of a white mannequin wearing ALL of these items as a coo
 
         return image_parts
 
+    @observe(as_type="generation", name="vton_generate_image")
     async def generate_outfit_image(self, request: VTONRequest) -> VTONResponse:
         """
         여러 패션 아이템 이미지로 코디된 모델 이미지 생성

--- a/app/outfit/vton_processor.py
+++ b/app/outfit/vton_processor.py
@@ -2,6 +2,7 @@ import asyncio
 import io
 import logging
 
+from langfuse.decorators import observe
 from PIL import Image
 
 from app.closet.s3_client import S3Client
@@ -16,6 +17,7 @@ class VTONProcessor:
         self.vton_client = vton_client or VTONClient()
         self.s3_client = S3Client()
 
+    @observe(name="vton_processor.process")
     async def process(
         self,
         response: OutfitResponse,

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,6 @@ prometheus-fastapi-instrumentator
 google-genai
 aiofiles
 openai
+langfuse>=2.0,<3.0
 
 # for cd test 2


### PR DESCRIPTION
## ⭐️ Issue Number



## 🚩 Summary

- Langfuse V2 SDK 연동 (Outfit 파이프라인 우선 적용)
- `@observe` 데코레이터를 활용한 분산 트레이싱으로 LLM 호출 관측성 확보
- OpenAI [chat_completion](cci:1://file:///Users/jeonghwan/Desktop/project/KlosetLab/app/outfit/llm_client.py:40:4-140:59), VTON 이미지 생성을 `generation` 타입으로 기록하여 토큰 사용량 및 지연시간 추적

## AS-IS

- LLM 호출(쿼리 파싱, 코디 추천, VTON)에 대한 관측성이 로그 기반으로만 존재하였습니다.
- 파이프라인 단계별 지연시간, 토큰 사용량, input/output을 통합적으로 확인할 방법 없었습니다

## TO-BE

- Langfuse 대시보드에서 Outfit 파이프라인 전체 트레이스를 계층적으로 확인 가능합니다.


## 🛠️ Technical Concerns
- **SDK 버전**: `langfuse>=2.0,<3.0`으로 고정 (Langfuse V2 서버 호환). V3 서버에도 하위 호환 가능
- **초기화 방식**: `langfuse_context.configure()`를 통해 `@observe` 데코레이터와 연결. `Langfuse()` 인스턴스 직접 생성이 아닌 decorator context 초기화 필수
- **데코레이터 순서**: `@observe`가 `@measure_time` 위에 위치하여 두 메트릭 모두 정상 동작
- **환경변수 미설정 시**: `langfuse_enabled=false`(기본값)이면 Langfuse 초기화를 스킵하여 기존 동작 보장