### PR TITLE
refactor: standardize kafka configuration and use KafkaTopics namespace

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,12 +55,8 @@ LANGFUSE_HOST=http://localhost:3001
 
 # Kafka Settings
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092
-KAFKA_ANALYZE_CONSUMER_GROUP=ai_analyze_worker_group
+KAFKA_GROUP_ID_CLOTHES_ANALYZE=ai_clothes_analyze_worker_group
 KAFKA_MAX_CONCURRENT_TASKS=20
-
-# Kafka Topics
-KAFKA_CLOSET_REQUEST_TOPIC=ai.clothes.analyze.request
-KAFKA_CLOSET_RESULT_TOPIC=ai.clothes.analyze.result
 
 # Backend Internal API (for presigned URLs)
 BACKEND_INTERNAL_URL=http://your_backend_internal_ip

--- a/app/closet/handler.py
+++ b/app/closet/handler.py
@@ -23,7 +23,7 @@ from app.closet.events import (
     serialize_event,
 )
 from app.closet.service import ClosetService
-from app.config import get_settings
+from app.config import KafkaTopics
 from app.core.kafka import get_kafka_producer
 
 logger = logging.getLogger(__name__)
@@ -54,7 +54,6 @@ def create_handler(consumer: AIOKafkaConsumer) -> MessageHandler:
 
     async def handle_analysis_request(message: ConsumerRecord) -> None:
         """Kafka 메시지 1건을 수신하여 ClosetService에 처리를 위임하고 결과를 발행합니다."""
-        settings = get_settings()
         producer = get_kafka_producer()
 
         # 1. 메시지 역직렬화
@@ -87,7 +86,7 @@ def create_handler(consumer: AIOKafkaConsumer) -> MessageHandler:
                 ),
             )
             await producer.send_and_wait(
-                settings.kafka_closet_result_topic,
+                KafkaTopics.CLOTHES_ANALYZE_RESULT,
                 serialize_event(preprocess_event),
             )
             logger.info(f"전처리 완료: task={req.task_id}")
@@ -108,7 +107,7 @@ def create_handler(consumer: AIOKafkaConsumer) -> MessageHandler:
                 ),
             )
             await producer.send_and_wait(
-                settings.kafka_closet_result_topic,
+                KafkaTopics.CLOTHES_ANALYZE_RESULT,
                 serialize_event(analyze_event),
             )
             logger.info(f"분석 완료: task={req.task_id}")

--- a/app/config.py
+++ b/app/config.py
@@ -4,6 +4,14 @@ from functools import lru_cache
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+
+# ── Kafka Topics (Code-level Constants) ──
+# 토픽 이름은 서비스 간의 규약(Contract)이므로 코드 내 상수로 관리합니다.
+class KafkaTopics:
+    CLOTHES_ANALYZE_REQUEST = "ai.clothes.analyze.request"
+    CLOTHES_ANALYZE_RESULT = "ai.clothes.analyze.result"
+
+
 # 핸들러 타입
 MessageHandler = Callable[..., Coroutine[object, object, None]]
 HandlerFactory = Callable[..., MessageHandler]
@@ -79,14 +87,9 @@ class Settings(BaseSettings):
     kafka_bootstrap_servers: str = Field(
         default="localhost:9092", alias="KAFKA_BOOTSTRAP_SERVERS"
     )
-    kafka_closet_request_topic: str = Field(
-        default="ai.clothes.analyze.request", alias="KAFKA_CLOSET_REQUEST_TOPIC"
-    )
-    kafka_closet_result_topic: str = Field(
-        default="ai.clothes.analyze.result", alias="KAFKA_CLOSET_RESULT_TOPIC"
-    )
-    kafka_analyze_consumer_group: str = Field(
-        default="ai_analyze_worker_group", alias="KAFKA_ANALYZE_CONSUMER_GROUP"
+    kafka_group_id_clothes_analyze: str = Field(
+        default="ai_clothes_analyze_worker_group",
+        alias="KAFKA_GROUP_ID_CLOTHES_ANALYZE",
     )
     kafka_max_concurrent_tasks: int = Field(
         default=50, alias="KAFKA_MAX_CONCURRENT_TASKS"

--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,11 @@ from fastapi.responses import JSONResponse
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.closet.handler import create_handler as create_closet_handler
-from app.config import ConsumerConfig, get_settings
+from app.config import (
+    ConsumerConfig,
+    KafkaTopics,
+    get_settings,
+)
 from app.core.consumer import consume_loop
 from app.core.database import check_health, close_databases, init_databases
 from app.core.kafka import (
@@ -33,8 +37,8 @@ settings = get_settings()
 # 새 기능 추가 시 이 리스트에 ConsumerConfig를 추가하면 됩니다.
 CONSUMER_CONFIGS: list[ConsumerConfig] = [
     ConsumerConfig(
-        topic=settings.kafka_closet_request_topic,
-        group_id=settings.kafka_analyze_consumer_group,
+        topic=KafkaTopics.CLOTHES_ANALYZE_REQUEST,
+        group_id=settings.kafka_group_id_clothes_analyze,
         handler_factory=create_closet_handler,
         replicas=3,
     ),


### PR DESCRIPTION
## ⭐️ Issue Number


- #130 


## 🚩 Summary

- 기존에 환경변수(.env)로 관리하던 토픽 이름을 코드 내 상수 네임스페이스로 이동했습니다.
- 환경별로 달라지는 설정(브로커 주소, 컨슈머 그룹 ID)은 환경변수로 유지하되, 명칭을 더 직관적으로 변경했습니다 
(KAFKA_ANALYZE_CONSUMER_GROUP → KAFKA_GROUP_ID_CLOTHES_ANALYZE)

## AS-IS

## TO-BE


## 🛠️ Technical Concerns

## 🙂 To Reviewer
