### PR TITLE
Langfuse score 기록 이슈 해결

### DIFF
--- a/app/outfit/graph/nodes/quality.py
+++ b/app/outfit/graph/nodes/quality.py
@@ -252,7 +252,7 @@ async def evaluate_quality(state: OutfitGraphState, config: RunnableConfig) -> d
 
     try:
         langfuse = get_client()
-        if langfuse and langfuse.enabled:
+        if langfuse:
             langfuse.score(
                 trace_id=trace_id,
                 name=f"outfit_confidence_attempt_{quality_retry_count}",
@@ -266,9 +266,10 @@ async def evaluate_quality(state: OutfitGraphState, config: RunnableConfig) -> d
                     value=len(all_critical_issues),
                     comment=", ".join(all_critical_issues),
                 )
+            langfuse.flush()
     except Exception as e:
-        logger.debug(
-            f"Langfuse score recording skipped | trace_id={trace_id} error={e}"
+        logger.warning(
+            f"Langfuse score recording failed | trace_id={trace_id} error={e}"
         )
 
     return {


### PR DESCRIPTION
## ⭐️ Issue Number



## 🚩 Summary

- Langfuse score가 대시보드에 기록되지 않는 문제 수정
- `langfuse.enabled` 불필요한 체크 제거
- `langfuse.flush()` 추가로 비동기 전송 보장
- 로그 레벨을 `debug` → `warning`으로 변경하여 실패 시 가시성 확보

## Changes

| 항목 | Before | After |
|------|--------|-------|
| enabled 체크 | `if langfuse and langfuse.enabled:` | `if langfuse:` |
| flush | 없음 | `langfuse.flush()` 추가 |
| 로그 레벨 | `logger.debug` | `logger.warning` |

## Root Cause

1. **`langfuse.enabled` 체크**: `LangfuseCallbackHandler` 내부용 속성으로, `get_client()`로 가져온 클라이언트에서 직접 `score()`를 호출할 때는 불필요하게 실행을 막을 수 있음
2. **`flush()` 누락**: Langfuse 클라이언트는 비동기 배치 전송 방식이라, `flush()` 없이 함수가 종료되면 버퍼가 전송되기 전에 다음 노드로 넘어감
3. **`logger.debug`**: 실패해도 로그에 출력되지 않아 문제 파악 불가

