### PR TITLE
Langgraph v3SDK에 맞춰 수정

### DIFF
--- a/app/outfit/graph/nodes/quality.py
+++ b/app/outfit/graph/nodes/quality.py
@@ -257,6 +257,7 @@ async def evaluate_quality(state: OutfitGraphState, config: RunnableConfig) -> d
                 trace_id=trace_id,
                 name=f"outfit_confidence_attempt_{quality_retry_count}",
                 value=avg_confidence,
+                data_type="NUMERIC",
                 comment=f"valid={len(valid_outfits)}/{len(outfits)}, issues={len(all_issues)}",
             )
             if all_critical_issues:
@@ -264,6 +265,7 @@ async def evaluate_quality(state: OutfitGraphState, config: RunnableConfig) -> d
                     trace_id=trace_id,
                     name=f"critical_issues_attempt_{quality_retry_count}",
                     value=len(all_critical_issues),
+                    data_type="NUMERIC",
                     comment=", ".join(all_critical_issues),
                 )
             langfuse.flush()


### PR DESCRIPTION
## ⭐️ Issue Number



## 🚩 Summary

- Langfuse score가 대시보드에 기록되지 않는 문제 수정
- Langfuse v3 SDK API 변경 반영 (`score()` → `create_score()`)
- `langfuse.enabled` 불필요한 체크 제거
- `langfuse.flush()` 추가로 비동기 전송 보장
- 로그 레벨을 `debug` → `warning`으로 변경하여 실패 시 가시성 확보

## Root Cause

1. **v3 API 변경**: Langfuse v3 SDK에서 `score()` → `create_score()`로 메서드명 변경됨. 기존 코드는 `AttributeError` 발생
2. **`langfuse.enabled` 체크**: `LangfuseCallbackHandler` 내부용 속성으로, `get_client()`로 가져온 클라이언트에서 직접 호출할 때는 불필요
3. **`flush()` 누락**: Langfuse 클라이언트는 비동기 배치 전송 방식이라, `flush()` 없이 함수가 종료되면 버퍼가 전송되기 전에 다음 노드로 넘어감
4. **`logger.debug`**: 실패해도 로그에 출력되지 않아 문제 파악 불가
